### PR TITLE
add md to html support

### DIFF
--- a/assets/assetpack.db
+++ b/assets/assetpack.db
@@ -206,10 +206,10 @@ format=js
 minified=0
 mtime=1456663191
 [riot:riot/dialog-message.tag]
-checksum=80d09974bc
+checksum=76b93ef296
 format=js
 minified=0
-mtime=1456670546
+mtime=1456787877
 [riot:riot/new-dialog.tag]
 checksum=f526f50501
 format=js

--- a/assets/assetpack.def
+++ b/assets/assetpack.def
@@ -5,6 +5,7 @@
 ! convos.js
 < http://code.jquery.com/jquery-1.11.3.min.js
 < js/autolink.js
+< js/mdtohtml.js
 < js/storage.js
 < js/window.js
 < https://cdnjs.cloudflare.com/ajax/libs/riot/2.3.15/riot.min.js

--- a/assets/cache/dialog-message-82480c7e44.js
+++ b/assets/cache/dialog-message-82480c7e44.js
@@ -23,7 +23,7 @@ riot.tag2('dialog-message', '<div class="message" if="{!msg.special}"></div> <di
   this.on('mount', function() {
     if (this.msg.special) return;
     $('.message', this.root).html(
-      this.msg.message.xmlEscape().autoLink({
+      this.msg.message.xmlEscape().mdToHtml().autoLink({
         target: '_blank',
         after: function(url, id) {
           $.get('/api/embed?url=' + encodeURIComponent(url), this.loadOffScreen);

--- a/assets/js/mdtohtml.js
+++ b/assets/js/mdtohtml.js
@@ -1,0 +1,33 @@
+// This code is based on http://stackoverflow.com/a/1319869
+// Originally writen by karim79 (http://stackoverflow.com/users/70393/karim79).
+//
+(function() {
+  String.prototype['mdToHtml'] = function() {
+    var tempStr = this;
+    while(tempStr.indexOf("**") !== -1) {
+        var firstPos = tempStr.indexOf("**");
+        var nextPos = tempStr.indexOf("**",firstPos + 2);
+        if(nextPos !== -1) {
+            var innerTxt = tempStr.substring(firstPos + 2,nextPos);
+            var strongified = '<b>' + innerTxt + '</b>';
+            tempStr = tempStr.substring(0,firstPos) + strongified + tempStr.substring(nextPos + 2,tempStr.length);
+        //get rid of unclosed '**'
+        //} else {
+        //    tempStr = tempStr.replace('**','');
+        }
+    }
+     while(tempStr.indexOf("*") !== -1) {
+        var firstPos = tempStr.indexOf("*");
+        var nextPos = tempStr.indexOf("*",firstPos + 1);
+        if(nextPos !== -1) {
+            var innerTxt = tempStr.substring(firstPos + 1,nextPos);
+            var italicized = '<i>' + innerTxt + '</i>';
+            tempStr = tempStr.substring(0,firstPos) + italicized + tempStr.substring(nextPos + 2,tempStr.length);
+        //get rid of unclosed '*'
+        //} else {
+        //    tempStr = tempStr.replace('*','');
+        }
+    }
+    return tempStr;
+  };
+})();

--- a/assets/riot/dialog-message.tag
+++ b/assets/riot/dialog-message.tag
@@ -40,7 +40,7 @@
   this.on('mount', function() {
     if (this.msg.special) return;
     $('.message', this.root).html(
-      this.msg.message.xmlEscape().autoLink({
+      this.msg.message.xmlEscape().mdToHtml().autoLink({
         target: '_blank',
         after: function(url, id) {
           $.get('/api/embed?url=' + encodeURIComponent(url), this.loadOffScreen);


### PR DESCRIPTION
This implementation has problems.  What do you think about the methodology of the implementation?

- It chops off a character after converting to html.  I could use help with this.
- It supports `*` only, and not `_`.  Markdown, IIRC, supports `*` and `_` interchangeably.
- `<strong>` didn't seem to work, so I used `<b>` instead.  IIRC, `<em>` *did* work.
- Is there any other markdown type that should be supported?
- I would have created a test, but I couldn't find an existing test that tested `autoLink()` to copy from.

If this implementation methodology is acceptable, it seems that this would also be the way to handle emoticons / emoji.  What is the opinion of support for either of these?