### PR TITLE
Prevent confidential data from leaking in whois

### DIFF
--- a/lib/Convos/Core/Connection.pm
+++ b/lib/Convos/Core/Connection.pm
@@ -486,7 +486,7 @@ sub irc_rpl_whoisuser {
   my $nick   = $params->[1];
 
   $self->{whois}{$nick}{host}     = $params->[3];
-  $self->{whois}{$nick}{realname} = $params->[5];
+  $self->{whois}{$nick}{realname} = $params->[2];
   $self->{whois}{$nick}{user}     = $params->[2];
 }
 


### PR DESCRIPTION
Hi folks,

I just started using Convos today and I've never used Perl, so bear :bear: with me, but I noticed a potential security issue.

I'm running Convos behind nginx as a reverse proxy and SSL endpoint with basic auth.

In the Convos code the whois `realname` field appears to be populated with the full URI where the Convos instance is running. When using basic auth this means `user:password@domain.tld` is displayed in the whois info. This seems like a very bad thing, I patched it quickly by just duplicating the user string in the real name field.

Is there a better way to fix this?

Thanks!