### PR TITLE
sort dialogs without regards to leading non-word characters

### DIFF
--- a/assets/vue/convos-main-menu.vue
+++ b/assets/vue/convos-main-menu.vue
@@ -58,8 +58,8 @@ module.exports = {
       }
       else {
         sortBy = function(a, b) {
-          var ah = a.name.toLowerCase();
-          var bh = b.name.toLowerCase();
+          var ah = a.name.toLowerCase().replace(/^\W+/, '');
+          var bh = b.name.toLowerCase().replace(/^\W+/, '');
           return ah < bh ? -1 : ah > bh ? 1 : 0;
         };
       }


### PR DESCRIPTION
It is confusing when ##thischannel comes before #somechannel because of
the double hash. Therefore sort after stripping leading non-word
characters.
