### PR TITLE
dialog ids (channel names) may contain a dot, so use relaxed placeholder

### DIFF
--- a/public/convos-api.json
+++ b/public/convos-api.json
@@ -29,6 +29,7 @@
       "name": "dialog_id",
       "in": "path",
       "default": "",
+      "x-mojo-placeholder": "#",
       "required": true,
       "type": "string",
       "description": "The name of the person or room"


### PR DESCRIPTION
IRC channel names, like say #chicago.pm may contain a dot. By default
mojolicious routes strip file-extension-like endings for format
detection. To avoid this use the relaxed placeholder "#".

This of course needs a test but I don't understand how the tests know what the channel name is.