### PR TITLE
Derive connection name based on ZNC usernames

### DIFF
--- a/lib/Convos/Controller/Connection.pm
+++ b/lib/Convos/Controller/Connection.pm
@@ -10,7 +10,7 @@ sub create {
   my $json = $self->req->json;
   my $url  = $self->_validate_url($json->{url})
     or return $self->render(openapi => E('Missing "host" in URL'), status => 400);
-  my $name = $json->{name} || $self->_pretty_connection_name($url->host);
+  my $name = $json->{name} || $self->_pretty_connection_name($url);
   my $connection;
 
   if (!$name) {
@@ -131,7 +131,16 @@ sub update {
 }
 
 sub _pretty_connection_name {
-  my ($self, $name) = @_;
+  my ($self, $url) = @_;
+
+  my $name = $url->host;
+  my ($username) = split(':', $url->userinfo || '');
+
+  # Support ZNC style logins
+  # <user>@<useragent>/<network>
+  if (defined($username) && ($username =~ /^(?<name>[a-z0-9_\+-]+)@(?<useragent>[a-z0-9_\+-]+)\/(?<network>[a-z0-9_\+-]+)/i)) {
+    return $+{network} if ($+{network});
+  }
 
   return '' unless defined $name;
   return 'magnet' if $name =~ /\birc\.perl\.org\b/i;    # also match ssl.irc.perl.org

--- a/t/connection_name.t
+++ b/t/connection_name.t
@@ -1,0 +1,11 @@
+use lib '.';
+use t::Helper;
+use Mojo::URL;
+use Convos::Controller::Connection;
+
+is (Convos::Controller::Connection::_pretty_connection_name(undef,Mojo::URL->new('irc://tyldum%40Convos%2Ffreenode:passw0rd@example.com:7000/')), 'freenode', 'ZNC style userinfo');
+is (Convos::Controller::Connection::_pretty_connection_name(undef,Mojo::URL->new('irc://user:passw0rd@example.com:7000/')), 'example', 'normal userinfo');
+is (Convos::Controller::Connection::_pretty_connection_name(undef,Mojo::URL->new('irc://example.com:7000/')), 'example', 'no userinfo');
+is (Convos::Controller::Connection::_pretty_connection_name(undef,Mojo::URL->new('irc://ssl.irc.perl.org/')), 'magnet', 'no userinfo');
+
+done_testing;


### PR DESCRIPTION
    ZNC is an IRC bouncer that supports multiple networks.
    By detecting the full login signature of <user>@<useragent>/<network> we
    can utilize this information.
    Even though <useragent> is optional in ZNC, it is mandatory for Convos
    to be able to securely detect this style login.
    
    The username given in Convos would look something like this:
        myuser@Convos/freenode
    And would produce a connection name of "freenode" wihin Convos, which
    would be displayed as "irc-freenode" in the frontend.

The bigger issue is a concept of networks within Convos, but this is good enough for me.