### PR TITLE
Add snap install documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,27 @@ frontend is held together by the progressive JavaScript framework
 
 # Quick start guide
 
+## Snap Install
+
+Install Convos in seconds on [Ubuntu and other snap supported Linux distributions](https://snapcraft.io/docs/core/install) with:
+
+    snap install convos
+
+Installing a snap is very quick. Snaps are secure. They are isolated with all of their dependencies. Snaps also auto update when a new version is released.
+
+## Shell Install
+
 ```bash
 curl https://convos.by/install.sh | sh -
 ./convos/script/convos daemon;
 ```
 
+## Start the daemon
+
 That's it! After the two commands above, you can point your browser to
 [http://localhost:3000](http://localhost:3000) and start chatting.
+
+## Invitation code
 
 Note that to register, you need a invitation code. This code is printed to
 screen as you start convos:


### PR DESCRIPTION
I see you've published Convos in the snap store! Thanks for snapping Convos it's pretty fantastic :-) I noticed you're missing snap install instructions meaning that many Linux users won't realise they could be installing an always updated snap.

This pull request adds installation instructions for users of [snap enabled Linux distributions](https://snapcraft.io/docs/core/install). Snaps enable ISVs and projects to make their software available to millions of Linux users via the snap store and directly control delivery of software updates to their users. Your software can be installed with `snap install convos` simplifying the installation instructions for your users.