### PR TITLE
Update Docker image to Alpine 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ FROM alpine:3.8
 MAINTAINER jhthorsen@cpan.org
 
 RUN \
-  apk add -U perl perl-io-socket-ssl && \
-  apk add -t builddeps build-base perl-dev wget && \
+  apk add --no-cache perl perl-io-socket-ssl && \
+  apk add --no-cache -t builddeps build-base perl-dev wget && \
   wget -q -O - https://github.com/Nordaaker/convos/archive/stable.tar.gz | tar xvz && \
   /convos-stable/script/convos install && \
   apk del builddeps && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,13 @@ FROM alpine:3.8
 MAINTAINER jhthorsen@cpan.org
 
 RUN \
-  apk add --no-cache perl perl-io-socket-ssl && \
-  apk add --no-cache -t builddeps build-base perl-dev wget && \
+  apk add --no-cache \
+    perl \
+    perl-io-socket-ssl && \
+  apk add --no-cache --virtual builddeps \
+    build-base \
+    perl-dev \
+    wget && \
   wget -q -O - https://github.com/Nordaaker/convos/archive/stable.tar.gz | tar xvz && \
   /convos-stable/script/convos install && \
   apk del builddeps && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # BUILD: docker build --no-cache --rm -t nordaaker/convos .
 # RUN:   docker run -it --rm -p 8080:3000 -v /var/convos/data:/data nordaaker/convos
-FROM alpine:3.5
+FROM alpine:3.8
 MAINTAINER jhthorsen@cpan.org
 
 RUN \


### PR DESCRIPTION
This makes the image smaller (as `/usr/share/perl5/core_perl/pod/` isn't filled with docs anymore) and also it's buildable on aarch64 (there is no alpine:3.5 image for aarch64 available).