### PR TITLE
window.document.hasFocus instead of window.hasFocus?

### DIFF
--- a/assets/js/notification.js
+++ b/assets/js/notification.js
@@ -43,7 +43,7 @@
 
   window.Notification.defaultCloseTimeout = 5000;
   window.Notification.simple = function(title, body, icon) {
-    if (window.hasFocus) return false;
+    if (window.document.hasFocus) return false;
     if (!icon) icon = defaultIcon;
 
     if (Notification.permission == 'granted') {


### PR DESCRIPTION
It could potentially be a setting. But I think that it's better to show notification, if possible. Because user may be at a different tab in the same window?..