### PR TITLE
Add handling for connection protocols, closes #311

### DIFF
--- a/assets/js/ConnURL.js
+++ b/assets/js/ConnURL.js
@@ -18,7 +18,7 @@ export default class ConnURL {
       },
     });
 
-    ['host', 'password', 'searchParams', 'username'].forEach(name => {
+    ['host', 'pathname', 'password', 'searchParams', 'username'].forEach(name => {
       Object.defineProperty(this, name, {
         get: () => this._url[name],
         set: (val) => {this._url[name] = val},

--- a/assets/js/md.js
+++ b/assets/js/md.js
@@ -14,7 +14,7 @@ import {regexpEscape} from './util';
 const codeToHtmlRe = new RegExp('(\\\\?)`([^`]+)`', 'g');
 const emojiByGroup = {};
 const emojiByName = {};
-const linkRe = new RegExp('https?://\\S+', 'g');
+const linkRe = new RegExp('\\b[a-z]{2,5}://\\S+', 'g');
 const mdLinkRe = new RegExp('\\[([^]+)\\]\\(([^)]+)\\)');
 const mdToHtmlRe = new RegExp('(^|\\s)(\\\\?)(\\*+|_+)(\\w[^<]*?)\\3', 'g');
 

--- a/assets/page/Chat.svelte
+++ b/assets/page/Chat.svelte
@@ -64,7 +64,7 @@ function addDialog(e) {
 function calculateDialog($user, $currentUrl) {
   pathParts = $currentUrl.pathParts;
   const c = $user.findDialog({connection_id: pathParts[1]}) || {};
-  if (c != connection) connection = c;
+  if (c != connection) registerUrlHandler(connection = c);
 
   const d = pathParts.length == 1 ? $user.notifications : $user.findDialog({connection_id: pathParts[1], dialog_id: pathParts[2]});
   if (!d) return (dialog = $user.notifications);
@@ -105,6 +105,12 @@ const onScroll = debounce(e => {
     messagesHeightLast = messagesHeight;
   }
 }, 20);
+
+function registerUrlHandler(connection) {
+  if (!connection.url) return;
+  const protocol = connection.url.protocol.replace(/:$/, '');
+  navigator.registerProtocolHandler(protocol, currentUrl.base + '/add/connection?uri=%s', 'Convos ' + protocol + ' handler');
+}
 </script>
 
 <svelte:window bind:innerHeight="{containerHeight}"/>


### PR DESCRIPTION
This PR adds the following features:

- Will ask the user to register the "irc" protocol, so if they click on a "irc://" link it will open in Convos
- The irc://... link will be passed on to /add/connection?uri=...
- &lt;ConnectionForm/> will parse the uri and see if:
  - The connection with the same hostname and the conversation exists. If so, the user is taken to /chat/irc-whatever/dialogName.
  - Check if just the connection exists. If so, the user is taken to /add/conversation?connection_id=irc-whatever&dialog_id=dialogName
  - If the connection does not exist, the &lt;ConnectionForm/> will be populated.

Other features/fixes:

- <ConnectionForm/> got a "dialog_id" field, so the user can add a single dialog to join after connected.
- ConnUrl.pathname accessor was added
- md() will convert anything that starts with a scheme into a link, and not just "http" and "https".