### PR TITLE
Fix the color on "textarea" focused element on dark theme

### DIFF
--- a/assets/sass/themes/_dark.scss
+++ b/assets/sass/themes/_dark.scss
@@ -23,7 +23,7 @@ html.theme-dark,
   --button-disabled-border: #373737;
   --button-danger-bg: #7c2b2b;
   --button-danger-color: #fff;
-  --input-bg: #050505;
+  --input-bg: #4e4d4d;
   --input-border: 1px solid #4e4e4e;
   --input-color: #c5c2bc;
   --input-focus-outline: 1px solid #c5c2bc;


### PR DESCRIPTION
**BEFORE**
![image](https://user-images.githubusercontent.com/27734319/68424605-a6a02980-01a4-11ea-8e80-864f9c538120.png)

**AFTER**
![image](https://user-images.githubusercontent.com/27734319/68425147-c84de080-01a5-11ea-9b3e-4f2c3362d47a.png)
