### PR TITLE
Fix $fa-font-path

### DIFF
--- a/assets/sass/_fonts.scss
+++ b/assets/sass/_fonts.scss
@@ -2,7 +2,7 @@
 @import 'fonts/sans';
 
 // https://fontawesome.com/icons
-$fa-font-path: "../../font/fa";
+$fa-font-path: "../font/fa";
 
 @import "../../node_modules/@fortawesome/fontawesome-free/scss/variables";
 @import "../../node_modules/@fortawesome/fontawesome-free/scss/mixins";


### PR DESCRIPTION
If Convos is put below a sub-path, a font is fetched from the wrong location. This patch changes $fa-font-path in assets/sass/_fonts.scss from "../../font/fa" to "../font/fa".

With "../../font/fa" Convos looks for the font directory at the wrong level. Example:
```
GET https://example.org/private/convos/asset/convos.development.css
GET https://example.org/private/font/fa/fa-solid-900.woff2
```

With "../font/fa" the font is always fetched from the right location.
```
GET https://example.org/private/convos/asset/convos.development.css
GET https://example.org/private/convos/font/fa/fa-solid-900.woff2
```

Excerpt from my Nginx configuration:

```
location /private/convos/ {
    proxy_pass http://localhost:8080/;
    proxy_set_header X-Request-Base "$scheme://$host/private/convos";
    [...]
}
```
