### PR TITLE
Add to Docker section about SELinux and exposing ports

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -104,6 +104,12 @@ docker run -it -p 8080:3000 \
 The last command will make Convos available on http://localhost:8080, and
 persist data in `$HOME/convos/data`.
 
+For Linux distributions with SELinux Enforcing policy (e.g. CentOS, Fedora or RHEL) append `:z` to volumes:
+
+```bash
+-v $HOME/convos/data:/data:z
+```
+
 There are some [alternative tags](https://hub.docker.com/r/nordaaker/convos/tags)
 available, but we suggest using the "stable" release.
 


### PR DESCRIPTION
I found these two notes were helpful when I was setting up Convos with Docker. 

The first one about exposing to localhost only (1c913f2) I thought was useful as I was only using it locally and didn't want to expose it anywhere else unnecessarily or accidentally.

The second one about Docker volumes and SELinux (18cccf0) is important because without it nothing can be written to the volume on the host (`$HOME/convos/data`).