### PR TITLE
fix exception when searching too long a period

### DIFF
--- a/lib/Convos/Core/Backend/File.pm
+++ b/lib/Convos/Core/Backend/File.pm
@@ -118,7 +118,7 @@ sub messages_p {
 
   # Do not search if the difference between "before" and "after" is more than 12 months
   # This limits the amount of time that could be spent searching and it also prevents DoS attacks
-  return Mojo::IOLoop->resolve([])
+  return Mojo::Promise->resolve([])
     if $args{before} - $args{after} > $args{before} - $args{before}->add_months(-12);
 
   # The {cursor} is used to walk through the month-hashed log files

--- a/t/backend-file-messages.t
+++ b/t/backend-file-messages.t
@@ -107,4 +107,9 @@ is int @{$t->tx->res->json->{messages} || []}, 28, 'server messages';
 $dialog = $connection->dialog({name => '#with/slash'});
 $t->get_ok('/api/connection/irc-localhost/dialog/%23with%2Fslash/messages.json')->status_is(200);
 
+$t->get_ok(
+  '/api/connection/irc-localhost/dialog/%23convos/messages?after=2015-06-09T02:39:51&before=2016-06-09T02:39:58'
+)->status_is(200);
+is int @{$t->tx->res->json->{messages} || []}, 0, 'after and before greater than 12 months';
+
 done_testing;


### PR DESCRIPTION
This fixes an exception I found in my logs about `Can't locate object
method "resolve" via package "Mojo::IOLoop" at
/app/script/../lib/Convos/Core/Backend/File.pm line 122.` Not sure
what's sending those requests, but it seems like the intent was to just
return nothing.