### PR TITLE
Do not use "convos green" for button and links but prefer red.

### DIFF
--- a/public/themes/high-contrast_color-scheme-dark.css
+++ b/public/themes/high-contrast_color-scheme-dark.css
@@ -6,17 +6,19 @@
 :root {
   --body-bg: #222222;
   --text-color: #fdfdfd;
-  --link-color: #b4eca0;
+  --link-color: #ff4444;
   --hr-border: 1px solid #333333;
   --error-color: #ee2222;
   --success-color: #338833;
-  --focus-outline: 0 0 1px 2px rgba(243, 218, 218, 0.4);
+  --focus-outline: 0 0 1px 2px rgba(243, 118, 118, 0.4);
   --highlight-color-bg: #000;
   --code-bg: #ccc;
-  --button-bg: #5f8961;
-  --button-border: 1px solid #444444;
+  --button-bg: #990000; 
+  --button-border: 1px solid #bb0000; 
   --button-danger-bg: #990000;
   --input-bg: #eee;
+  --button-disabled-bg: #440000;
+  --button-disabled-border: #373737;
   --input-focus-outline: 2px dotted #eee;
   --autocomplete-focus: #eeeeee;
   --autocomplete-focus-bg: #333333;
@@ -26,6 +28,6 @@
   --sidebar-left-text: #f8f8f8;
   --sidebar-left-border-bottom: #887d76;
   --sidebar-left-search-placeholder-color: #999999;
-  --sidebar-left-search-focus-bg: #5f8961;
+  --sidebar-left-search-focus-bg: #990000; 
   --syntax-hl-base-bg: #fff;
 }

--- a/public/themes/high-contrast_color-scheme-light.css
+++ b/public/themes/high-contrast_color-scheme-light.css
@@ -5,16 +5,18 @@
 
 :root {
   --body-bg: #fdfdfd;
-  --link-color: #31930d;
+  --link-color: #bb3333;
   --hr-border: 1px solid #333333;
   --error-color: #ee2222;
   --success-color: #338833;
-  --focus-outline: 0 0 1px 2px rgba(243, 218, 218, 0.4);
+  --focus-outline: 0 0 1px 2px rgba(243, 118, 118, 0.4);
   --highlight-color-bg: #ffc4c4;
   --code-bg: #ccc;
-  --button-bg: #5f8961;
-  --button-border: 1px solid #444444;
+  --button-bg: #990000; 
+  --button-border: 1px solid #bb0000; 
   --button-danger-bg: #990000;
+  --button-disabled-bg: #ffb3b3;
+  --button-disabled-border: #373737;
   --input-focus-outline: 2px dotted #eee;
   --autocomplete-focus: #eeeeee;
   --autocomplete-focus-bg: #333333;
@@ -24,6 +26,6 @@
   --sidebar-left-text: #f8f8f8;
   --sidebar-left-border-bottom: #887d76;
   --sidebar-left-search-placeholder-color: #999999;
-  --sidebar-left-search-focus-bg: #5f8961;
+  --sidebar-left-search-focus-bg: #990000; 
   --syntax-hl-base-bg: #fff;
 }


### PR DESCRIPTION
Hello,

I really like (new ?) high-contrast theme especially light version but I'm not very happy with keeping "convos green" for links and buttons.

I propose to change it to red for both light and dark version with minor diffs (disabled button is darker on dark version where it is lighter on light version + link color not exactly the same)

It could be also a new theme if some people do not agree with my vision and want to keep the current themes.

Or you can edit it or just get inspired for doing something else and decline this PR, I'm not an UX designer and it's probably not perfect :)

Here is a preview : https://imgur.com/a/pFRwn7x

Best regards.

Thibault