### PR TITLE
Better button outline + light gray for right sidebar (ligth version)

### DIFF
--- a/public/themes/high-contrast_color-scheme-dark.css
+++ b/public/themes/high-contrast_color-scheme-dark.css
@@ -19,6 +19,7 @@
   --input-bg: #eee;
   --button-disabled-bg: #440000;
   --button-disabled-border: #373737;
+  --button-focus-outline: 1px solid #ff9999;
   --input-focus-outline: 2px dotted #eee;
   --autocomplete-focus: #eeeeee;
   --autocomplete-focus-bg: #333333;

--- a/public/themes/high-contrast_color-scheme-light.css
+++ b/public/themes/high-contrast_color-scheme-light.css
@@ -17,9 +17,11 @@
   --button-danger-bg: #990000;
   --button-disabled-bg: #ffb3b3;
   --button-disabled-border: #373737;
+  --button-focus-outline: 1px solid #ff9999;
   --input-focus-outline: 2px dotted #eee;
   --autocomplete-focus: #eeeeee;
   --autocomplete-focus-bg: #333333;
+  --sidebar-right-bg: #f8f8f8;
   --sidebar-left-bg: #222222;
   --sidebar-left-border: 1px solid #000000;
   --sidebar-left-frozen-color: #aaaaaa;


### PR DESCRIPTION
Hello,

Just a small update to retrofit the button focus outline and the very light gray on the right sidebar (only light version)

Preview : 

Focus outline before change : 
![convos13](https://user-images.githubusercontent.com/580360/82020316-25f94300-9689-11ea-9466-d5414f999927.png)

Focus outline after : 
![convos14](https://user-images.githubusercontent.com/580360/82020314-2560ac80-9689-11ea-97a0-e4a38d346333.png)
(maybe not perfect as is but at least should not be green)

Sidebar after change : 
![convos12](https://user-images.githubusercontent.com/580360/82020317-2691d980-9689-11ea-9457-763c42ddca22.png)


Best regards.

Thibault
