### PR TITLE
Reduce docker image size.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,22 +5,19 @@
 # BUILD: docker build --no-cache --rm -t nordaaker/convos .
 # RUN:   docker run -it --rm -p 8080:3000 -v /var/convos/data:/data nordaaker/convos
 FROM alpine:3.11
-MAINTAINER jhthorsen@cpan.org
+LABEL maintainer="jhthorsen@cpan.org"
 
-RUN mkdir /app && \
-  apk add --no-cache perl perl-io-socket-ssl wget && \
-  apk add --no-cache --virtual builddeps build-base perl-dev
-
-COPY Changes /app/
-COPY cpanfile /app/
+RUN mkdir /app
+COPY Changes cpanfile /app/
 COPY assets /app/assets
 COPY lib /app/lib
 COPY public /app/public
 COPY script /app/script
 COPY templates /app/templates
-
-RUN /app/script/convos install --all
-RUN apk del builddeps && rm -rf /root/.cpanm /var/cache/apk/*
+RUN apk add --no-cache perl perl-io-socket-ssl wget && \
+    apk add --no-cache --virtual builddeps build-base perl-dev && \
+    /app/script/convos install --all && \
+    apk del builddeps && rm -rf /root/.cpanm /var/cache/apk/*
 
 # Do not change these variables unless you know what you're doing
 ENV CONVOS_HOME /data


### PR DESCRIPTION
Run `apk add`, `convos install` and cleanup in one RUN statement
to avoid extra layer creation. Reduces the image size from 269
to 59 MB:

```
marcus/convos       latest     33235db3041d        6 seconds ago       59MB
nordaaker/convos    latest     6edb9449fdce        9 hours ago         296MB
```