### PR TITLE
Add users editor

### DIFF
--- a/assets/components/OperationStatus.svelte
+++ b/assets/components/OperationStatus.svelte
@@ -1,10 +1,31 @@
 <script>
-import {l} from '../js/i18n';
 import Operation from '../store/Operation';
+import {l} from '../js/i18n';
+import {onDestroy} from 'svelte';
 
+export let progress = false;
 export let op = new Operation({});
+
+let pct = 0;
+let tid;
+
+$: calculateProgress($op, progress);
+
+onDestroy(() => (tid && clearTimeout(tid)));
+
+function calculateProgress($op, progress) {
+  if (tid) clearTimeout(tid);
+  if (!$op.is('loading')) return;
+  if (typeof progress == 'number') return (pct = progress);
+  pct = 0;
+  tid = setInterval(() => (++pct), 500);
+}
 </script>
 
 {#if $op.is('error')}
   <div class="error">{l($op.error())}</div>
+{:else if progress !== false && $op.is('loading')}
+  <div class="progress">
+    <div class="progress__bar" style="width:{pct}%;">{l('Loading...')}</div>
+  </div>
 {/if}

--- a/assets/components/SidebarChat.svelte
+++ b/assets/components/SidebarChat.svelte
@@ -195,6 +195,10 @@ function renderUnread(dialog) {
         <Icon name="tools"/>
         <span>{l('Settings')}</span>
       </Link>
+      <Link href="/settings/users">
+        <Icon name="users"/>
+        <span>{l('Users')}</span>
+      </Link>
     {/if}
     <a href="{route.urlFor('/logout')}" target="_self">
       <Icon name="power-off"/>

--- a/assets/js/Time.js
+++ b/assets/js/Time.js
@@ -35,11 +35,11 @@ export default class Time extends Date {
    * @memberof Time
    * @returns {String} Example "Sept 15"
    */
-  getHumanDate() {
+  getHumanDate(params = {}) {
     let str = this.getMonthAbbr() + ' ' + this.getDate();
     const now = new Time();
     const sameYear = this.getYear() == now.getYear();
-    if (!sameYear) str += ', ' + this.getFullYear();
+    if (!sameYear || params.year) str += ', ' + this.getFullYear();
     return str;
   }
 

--- a/assets/page/SettingsAdmin.svelte
+++ b/assets/page/SettingsAdmin.svelte
@@ -14,12 +14,10 @@ const api = getContext('api');
 const user = getContext('user');
 
 const getSettingsOp = api('getSettings');
-const inviteLinkOp = api('inviteUser');
 const updateSettingsOp = api('updateSettings');
 
 let convosSettings = {};
 
-$: invite = $inviteLinkOp.res.body || {};
 $: diskUsage = calculateDiskUsage(convosSettings.disk_usage);
 
 updateSettingsOp.on('start', req => {
@@ -51,15 +49,6 @@ function calculateDiskUsage(usage) {
   };
 }
 
-function generateInviteLink(e) {
-  inviteLinkOp.perform(e.target);
-}
-
-function copyInviteLink(e) {
-  const copied = copyToClipboard(e.target);
-  if (copied) notify(copied, {title: l('Invite link copied')});
-}
-
 function updateSettingsFromForm(e) {
   updateSettingsOp.perform(e.target);
 }
@@ -70,30 +59,6 @@ function updateSettingsFromForm(e) {
 </ChatHeader>
 
 <main class="main">
-  <form id="recover-or-invite" method="post" on:submit|preventDefault="{generateInviteLink}">
-    <h2>{l('Recover or invite')}</h2>
-    <p>{l('Using this form, you can generate an invite link for new users, or a recover password link for existing users.')}</p>
-    <TextField type="email" name="email" placeholder="{l('user@example.com')}">
-      <span slot="label">{l('User email')}</span>
-    </TextField>
-
-    {#if invite.url}
-      <h3>{l('A link was generated')}</h3>
-      <p>
-        {@html lmd(invite.existing ? 'Copy and send the link to your *existing* user.' : 'Copy and send the link to your *new* user.')}
-        {@html lmd('The link is valid until **%1**.', new Date(invite.expires).toLocaleString())}
-      </p>
-      <a href="{invite.url}" on:click|preventDefault="{copyInviteLink}">{invite.url}</a>
-      <p><small>{l('Tip: Clicking on the link will copy it to your clipboard.')}</small></p>
-    {/if}
-
-    <div class="form-actions">
-      <Button icon="save" op="{inviteLinkOp}"><span>{l('Generate link')}</span></Button>
-    </div>
-
-    <OperationStatus op="{inviteLinkOp}"/>
-  </form>
-
   <form id="convos-settings" method="post" on:submit|preventDefault="{updateSettingsFromForm}">
     <h2>{l('Convos settings')}</h2>
     <p>{@html lmd('These settings control what users experience when they visit [%1](%1).', process.env.base_url)}</p>

--- a/assets/page/SettingsAdminUsers.svelte
+++ b/assets/page/SettingsAdminUsers.svelte
@@ -1,0 +1,160 @@
+<script>
+import Button from '../components/form/Button.svelte';
+import ChatHeader from '../components/ChatHeader.svelte';
+import Icon from '../components/Icon.svelte';
+import Link from '../components/Link.svelte';
+import OperationStatus from '../components/OperationStatus.svelte';
+import TextField from '../components/form/TextField.svelte';
+import Time from '../js/Time';
+import {getContext, onMount} from 'svelte';
+import {l, lmd} from '../js/i18n';
+import {route} from '../store/Route';
+
+const api = getContext('api');
+const user = getContext('user');
+
+const deleteUserOp = api('deleteUser');
+const getUsersOp = api('getUsers');
+const inviteLinkOp = api('inviteUser');
+const updateUserOp = api('updateUser');
+
+let confirmEmail = '';
+let users = [];
+
+route.update({title: l('Users')});
+
+$: editUser = findUser($route, users);
+$: invite = $inviteLinkOp.res.body || {};
+
+updateUserOp.on('start', req => {
+  editUser.roles = req.body.roles.split(/[.,\s]+/).map(str => str.trim());
+  req.body.roles = editUser.roles;
+});
+
+onMount(async () => {
+  await getUsersOp.perform();
+  users = getUsersOp.res.body.users || [];
+});
+
+function copyInviteLink(e) {
+  const copied = copyToClipboard(e.target);
+  if (copied) notify(copied, {title: l('Invite link copied')});
+}
+
+async function deleteUserFromForm(e) {
+  e.preventDefault();
+  deleteUserOp.reset();
+  updateUserOp.reset();
+  if (confirmEmail != editUser.email) return;
+
+  await deleteUserOp.perform(e.target);
+  if (!deleteUserOp.is('success')) return;
+
+  await getUsersOp.perform();
+  route.go('/settings/users', {replace: true});
+}
+
+function findUser(route, users) {
+  const uid = route.hash;
+  confirmEmail = '';
+  return users.filter(user => user.uid == uid)[0];
+}
+
+function generateInviteLink(e) {
+  inviteLinkOp.perform(e.target);
+}
+
+function updateUserFromForm(e) {
+  deleteUserOp.reset();
+  updateUserOp.perform(e.target);
+}
+</script>
+
+<ChatHeader>
+  <h1>{l(editUser ? 'Account' : 'Users')}</h1>
+  <Link href="/settings/users" class="btn can-toggle {editUser ? 'is-toggled' : ''}" data-tooltip="{l('See all users')}"><Icon name="list"/><Icon name="times"/></Link>
+</ChatHeader>
+
+<main class="main">
+  {#if editUser}
+    <form id="edit" method="post" on:submit|preventDefault="{updateUserFromForm}">
+      <TextField name="email" value="{editUser.email}" readonly>
+        <span slot="label">{l('Email')}</span>
+      </TextField>
+
+      <TextField name="roles" value="{editUser.roles.join(', ')}" placeholder="{l('admin, bot, ...')}">
+        <span slot="label">{l('Roles')}</span>
+        <p class="help" slot="help">{l('Roles must be separated by comma.')}</p>
+      </TextField>
+
+      <div class="form-actions">
+        <Button icon="save" op="{updateUserOp}"><span>{l('Save user')}</span></Button>
+      </div>
+
+      <OperationStatus op="{updateUserOp}"/>
+    </form>
+
+    <h2>Delete account</h2>
+    <form id="delete" method="post" on:submit|preventDefault="{deleteUserFromForm}">
+      <p>
+        {l('This will permanently remove user settings, chat logs, uploaded files and other user related data.')}
+        {@html lmd('Please confirm by entering **%1** before hitting **%2**.', editUser.email, l('Delete user'))}
+      </p>
+
+      <TextField name="email" bind:value="{confirmEmail}">
+        <span slot="label">{l('Confirm email')}</span>
+      </TextField>
+
+      <div class="form-actions">
+        <Button icon="trash" op="{deleteUserOp}" disabled="{confirmEmail != editUser.email}"><span>{l('Delete user')}</span></Button>
+      </div>
+
+      <OperationStatus op="{deleteUserOp}"/>
+    </form>
+  {:else}
+    <form id="invite" method="post" on:submit|preventDefault="{generateInviteLink}">
+      <h2>{l('Invite')}</h2>
+      <TextField type="email" name="email" placeholder="{l('user@example.com')}">
+        <span slot="label">{l('User email')}</span>
+        <p class="help" slot="help">{l('Using this form, you can generate an invite link for new users.')}</p>
+      </TextField>
+
+      {#if invite.url}
+        <h3>{l('A link was generated')}</h3>
+        <p>
+          {@html lmd(invite.existing ? 'Copy and send the link to your *existing* user.' : 'Copy and send the link to your *new* user.')}
+          {@html lmd('The link is valid until **%1**.', new Date(invite.expires).toLocaleString())}
+        </p>
+        <a href="{invite.url}" on:click|preventDefault="{copyInviteLink}">{invite.url}</a>
+        <p><small>{l('Tip: Clicking on the link will copy it to your clipboard.')}</small></p>
+      {/if}
+
+      <div class="form-actions">
+        <Button icon="save" op="{inviteLinkOp}"><span>{l('Generate link')}</span></Button>
+      </div>
+
+      <OperationStatus op="{inviteLinkOp}"/>
+    </form>
+
+    <h2>{l('Users')}</h2>
+    <OperationStatus op="{getUsersOp}" progress="{true}"/>
+    <table>
+      <thead>
+        <tr>
+          <th>Email</th>
+          <th>Roles</th>
+          <th>Registered</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each users as user}
+          <tr>
+            <td><a href="#{user.uid}">{user.email}</a></td>
+            <td>{user.roles.join(', ')}</td>
+            <td>{new Time(user.registered).getHumanDate({year: true})}</td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  {/if}
+</main>

--- a/assets/routes.js
+++ b/assets/routes.js
@@ -1,4 +1,3 @@
-
 import Chat from './page/Chat.svelte';
 import ConnectionAdd from './page/ConnectionAdd.svelte';
 import DialogAdd from './page/DialogAdd.svelte';
@@ -8,6 +7,7 @@ import Login from './page/Login.svelte';
 import Search from './page/Search.svelte';
 import SettingsAccount from './page/SettingsAccount.svelte';
 import SettingsAdmin from './page/SettingsAdmin.svelte';
+import SettingsAdminUsers from './page/SettingsAdminUsers.svelte';
 
 export function setupRouting(route, user) {
   route.to('/login', render(Login));
@@ -17,6 +17,7 @@ export function setupRouting(route, user) {
   route.to('/settings/account', render(SettingsAccount));
   route.to('/settings/connection', render(ConnectionAdd));
   route.to('/settings/conversation', render(DialogAdd));
+  route.to('/settings/users', render(SettingsAdminUsers));
   route.to('/settings', render(SettingsAdmin));
   route.to('/search', render(Search));
 

--- a/assets/sass/components/_form.scss
+++ b/assets/sass/components/_form.scss
@@ -381,5 +381,7 @@ input[type="file"]:-webkit-file-upload-button {
   text-shadow: 0 1px 2px var(--button-bg);
   padding-left: 4px;
   padding-right: 4px;
+  max-width: 100%;
   overflow: visible;
+  transition: width 0.5s ease-in;
 }

--- a/lib/Convos/Controller/User.pm
+++ b/lib/Convos/Controller/User.pm
@@ -56,6 +56,13 @@ sub get {
   });
 }
 
+sub list {
+  my $self       = shift->openapi->valid_input  or return;
+  my $admin_from = $self->user_has_admin_rights or return $self->reply->errors([], 401);
+  my $users      = $self->app->core->users;
+  $self->render(openapi => {users => $users});
+}
+
 sub login {
   my $self = shift->openapi->valid_input or return;
 
@@ -280,6 +287,10 @@ See L<https://convos.chat/api.html#op-post--user--email--invite>
 =head2 get
 
 See L<https://convos.chat/api.html#op-get--user>
+
+=head2 list
+
+See L<https://convos.chat/api.html#op-get--users>
 
 =head2 login
 

--- a/lib/Convos/Controller/User.pm
+++ b/lib/Convos/Controller/User.pm
@@ -8,30 +8,23 @@ use Socket qw(inet_aton AF_INET);
 
 use constant INVITE_LINK_VALID_FOR => $ENV{CONVOS_INVITE_LINK_VALID_FOR} || 24;
 
-sub delete {
-  my $self = shift->openapi->valid_input or return;
-  my $user = $self->backend->user        or return $self->reply->errors([], 401);
-
-  return $self->reply->errors('You are the only user left.', 400)
-    if @{$self->app->core->users} <= 1;
-
-  return $self->app->core->backend->delete_object_p($user)->then(sub {
-    delete $self->session->{email};
-    $self->render(openapi => {message => 'You have been erased.'});
-  });
-}
+has _email => sub {
+  my $email = shift->param('email') || '';
+  $email =~ s!\.json$!!;
+  return trim $email;
+};
 
 sub generate_invite_link {
   my $self = shift->openapi->valid_input or return;
   return $self->reply->errors([], 401) unless my $admin_from = $self->user_has_admin_rights;
 
   my $exp      = time + ($self->param('exp') || INVITE_LINK_VALID_FOR) * 3600;
-  my $user     = $self->app->core->get_user($self->stash('email'));
+  my $user     = $self->app->core->get_user($self->_email);
   my $password = $user ? $user->password : $self->settings('local_secret');
 
   my $params
     = $self->_add_invite_token_to_params(
-    {email => $self->stash('email'), exp => $exp, password => $password},
+    {email => $self->_email, exp => $exp, password => $password},
     $self->app->secrets->[0]);
 
   my $invite_url = $self->url_for('register');
@@ -57,9 +50,10 @@ sub get {
 }
 
 sub list {
-  my $self       = shift->openapi->valid_input  or return;
-  my $admin_from = $self->user_has_admin_rights or return $self->reply->errors([], 401);
-  my $users      = $self->app->core->users;
+  my $self       = shift->openapi->valid_input or return;
+  my $admin_from = $self->user_has_admin_rights
+    or return $self->reply->errors('Only admins can list users.', 403);
+  my $users = $self->app->core->users;
   $self->render(openapi => {users => $users});
 }
 
@@ -93,7 +87,7 @@ sub register {
   my $json = $self->_clean_json;
   my $user = $self->app->core->get_user($json->{email});
 
-  # The first user can join without invite link
+  # Only the first user can join without invite link
   if ($self->app->core->n_users) {
 
     # Validate input
@@ -103,9 +97,10 @@ sub register {
     # TODO: Add test
     return $self->reply->errors('Email is taken.', 401) if !$json->{token} and $user;
 
-    return $self->reply->errors('Invalid token. You have to ask your Convos admin for a new link.',
-      401)
-      if $json->{token} and !$self->_is_valid_invite_token($user, {%$json});
+    if ($json->{token} and !$self->_is_valid_invite_token($user, {%$json})) {
+      return $self->reply->errors(
+        'Invalid token. You have to ask your Convos admin for a new link.', 401);
+    }
 
     # Update existing user
     return $self->_update_user($json, $user) if $user;
@@ -136,10 +131,23 @@ sub register_html {
   $self->render('index');
 }
 
+sub remove {
+  my $self = shift->openapi->valid_input           or return;
+  my $user = $self->_get_user_from_param('delete') or return;
+
+  return $self->reply->errors('You are the only user left.', 400)
+    if @{$self->app->core->users} <= 1;
+
+  return $self->app->core->remove_user_p($user)->then(sub {
+    delete $self->session->{email} if $user->email eq $self->session('email');
+    $self->render(openapi => {message => 'Deleted.'});
+  });
+}
+
 sub update {
-  my $self = shift->openapi->valid_input or return;
+  my $self = shift->openapi->valid_input           or return;
+  my $user = $self->_get_user_from_param('update') or return;
   my $json = $self->_clean_json;
-  my $user = $self->backend->user or return $self->reply->errors([], 401);
 
   # TODO: Add support for changing email
 
@@ -163,8 +171,9 @@ sub _clean_json {
     delete $json->{$k} unless length $json->{$k};
   }
 
-  $json->{highlight_keywords} = [grep {/\w/} map { trim $_ } @{$json->{highlight_keywords}}]
-    if $json->{highlight_keywords};
+  for my $k (qw(highlight_keywords roles)) {
+    $json->{$k} = [grep {/\w/} map { trim $_ } @{$json->{$k}}] if $json->{$k};
+  }
 
   return $json;
 }
@@ -191,6 +200,21 @@ sub _existing_dialog {
   my ($self, $url, $conn) = @_;
   return undef unless my $dialog_name = $url->path->[0];
   return $conn->get_dialog(lc $dialog_name);
+}
+
+sub _get_user_from_param {
+  my ($self, $op) = @_;
+
+  my $user = $self->backend->user or return $self->reply->errors([], 401);
+  return $user if $user->email eq $self->_email;
+
+  return $self->reply->errors("Only admins can $op other users.", 403)
+    unless $self->user_has_admin_rights;
+
+  my $target_user = $self->app->core->get_user($self->_email);
+  return $target_user                                                   if $target_user;
+  return +($self->render(openapi => {message => 'Deleted.'}), undef)[1] if $op eq 'delete';
+  return $self->reply->errors('No such user.', 404);
 }
 
 sub _is_valid_invite_token {
@@ -238,8 +262,7 @@ sub _register_html_conn_url_redirect {
 sub _register_html_handle_invite_url {
   my $self = shift;
 
-  my $params
-    = {token => $self->param('token'), email => $self->param('email'), exp => $self->param('exp')};
+  my $params = {token => $self->param('token'), email => $self->_email, exp => $self->param('exp')};
 
   return unless $params->{token} and $params->{email} and $params->{exp};
   return $self->stash(status => 410) if $params->{exp} =~ m!\D! or $params->{exp} < time;
@@ -254,9 +277,11 @@ sub _update_user {
   my ($self, $json, $user) = @_;
 
   $user->highlight_keywords($json->{highlight_keywords}) if $json->{highlight_keywords};
-  $user->set_password($json->{password})                 if $json->{password};
+  $user->roles($json->{roles})           if $json->{roles} and $self->user_has_admin_rights;
+  $user->set_password($json->{password}) if $json->{password};
   $user->save_p->then(sub {
-    $self->session(email => $user->email);
+    my $session_email = $self->session('email');
+    $self->session(email => $user->email) if !$session_email or $user->email eq $session_email;
     $self->render(openapi => $user);
   });
 }
@@ -275,10 +300,6 @@ L<Convos::Controller::User> is a L<Mojolicious::Controller> with
 user related actions.
 
 =head1 METHODS
-
-=head2 delete
-
-See L<https://convos.chat/api.html#op-delete--user>
 
 =head2 generate_invite_link
 
@@ -307,6 +328,10 @@ See L<https://convos.chat/api.html#op-post--user-register>
 =head2 register_html
 
 Will handle the "uri" that can hold "irc://...." URLs.
+
+=head2 remove
+
+See L<https://convos.chat/api.html#op-delete--user>
 
 =head2 update
 

--- a/lib/Convos/Core.pm
+++ b/lib/Convos/Core.pm
@@ -67,6 +67,15 @@ sub new {
   return $self;
 }
 
+sub remove_user_p {
+  my ($self, $user) = @_;
+  my @p = $user->connections->map(sub { $user->remove_connection_p($_) })->each;
+  my $p = @p ? Mojo::Promise->all(@p) : Mojo::Promise->resolve;
+
+  return $p->then(sub { $self->backend->delete_object_p($user) })
+    ->then(sub { $self->remove_user($user->id); $user });
+}
+
 sub start {
   my $self = shift;
   return $self if !@_ and $self->{started}++;
@@ -291,6 +300,12 @@ Object constructor. Builds L</backend> if a classname is provided.
 
 Will start the backend. This means finding all users and start connections
 if state is not "disconnected".
+
+=head2 remove_user_p
+
+  $p = $core->remove_user_p($user)->then(sub { $user });
+
+Used to delete user data and remove the user from C<$core>.
 
 =head2 user
 

--- a/lib/Convos/Core/Settings.pm
+++ b/lib/Convos/Core/Settings.pm
@@ -13,7 +13,7 @@ has forced_connection =>
   sub { $ENV{CONVOS_FORCED_CONNECTION} || $ENV{CONVOS_FORCED_IRC_SERVER} ? true : false };
 sub id {'settings'}
 has local_secret   => sub { $ENV{CONVOS_LOCAL_SECRET} || generate_secret };
-has open_to_public => sub {false};
+has open_to_public => sub { $ENV{CONVOS_OPEN_TO_PUBLIC} ? true : false };
 has organization_name =>
   sub { $ENV{CONVOS_ORGANIZATION_NAME} || shift->defaults->{organization_name} };
 has organization_url =>

--- a/lib/Convos/Util.pm
+++ b/lib/Convos/Util.pm
@@ -57,7 +57,8 @@ sub has_many {
   $singular_accessor =~ s!s$!!;
 
   monkey_patch $class => $plural_accessor => sub {
-    return c(values %{$_[0]->{$plural_accessor} || {}});
+    my $all = $_[0]->{$plural_accessor} || {};
+    return c(map { $all->{$_} } sort keys %$all);
   };
 
   monkey_patch $class => "n_$plural_accessor" => sub {

--- a/public/convos-api.yaml
+++ b/public/convos-api.yaml
@@ -427,16 +427,6 @@ paths:
             $ref: '#/definitions/ServerSettings'
 
   /user:
-    delete:
-      operationId: deleteUser
-      summary: Delete a user.
-      tags: [ user ]
-      x-mojo-to: user#delete
-      responses:
-        '200':
-          description: Successfully deleted.
-          schema:
-            $ref: '#/definitions/Success'
     get:
       operationId: getUser
       summary: Get user data.
@@ -451,29 +441,6 @@ paths:
         in: query
         name: dialogs
         type: boolean
-      responses:
-        '200':
-          description: User profile.
-          schema:
-            $ref: '#/definitions/User'
-    post:
-      operationId: updateUser
-      summary: Update an existing user.
-      tags: [ user ]
-      x-mojo-to: user#update
-      parameters:
-      - in: body
-        name: body
-        required: true
-        schema:
-          type: object
-          properties:
-            highlight_keywords:
-              description: Extra keywords to highlight on
-              items:
-                type: string
-            password:
-              $ref: '#/definitions/Password'
       responses:
         '200':
           description: User profile.
@@ -552,6 +519,49 @@ paths:
           schema:
             $ref: '#/definitions/User'
 
+  /user/{email}:
+    delete:
+      operationId: deleteUser
+      summary: Delete a user.
+      tags: [ user ]
+      x-mojo-to: user#remove
+      parameters:
+      - $ref: '#/parameters/email_in_path'
+      responses:
+        '200':
+          description: Successfully deleted.
+          schema:
+            $ref: '#/definitions/Success'
+    post:
+      operationId: updateUser
+      summary: Update an existing user.
+      tags: [ user ]
+      x-mojo-to: user#update
+      parameters:
+      - $ref: '#/parameters/email_in_path'
+      - in: body
+        name: body
+        required: true
+        schema:
+          type: object
+          properties:
+            highlight_keywords:
+              description: Extra keywords to highlight on
+              items:
+                type: string
+            password:
+              $ref: '#/definitions/Password'
+            roles:
+              description: User roles, such as admin and bot.
+              type: array
+              items:
+                type: string
+      responses:
+        '200':
+          description: User profile.
+          schema:
+            $ref: '#/definitions/User'
+
   /user/{email}/invite:
     post:
       operationId: inviteUser
@@ -560,10 +570,6 @@ paths:
       x-mojo-to: user#generate_invite_link
       parameters:
       - $ref: '#/parameters/email_in_path'
-      - description: Role to give the user.
-        in: query
-        name: role
-        type: string
       responses:
         '200':
           description: User profile.

--- a/public/convos-api.yaml
+++ b/public/convos-api.yaml
@@ -579,6 +579,28 @@ paths:
               url:
                 type: string
 
+  /users:
+    get:
+      operationId: getUsers
+      summary: List Convos users
+      tags: [ user ]
+      x-mojo-to: user#list
+      parameters:
+      - description: Find users after in pagination
+        in: query
+        name: after
+        type: string
+      responses:
+        '200':
+          description: List of users.
+          schema:
+            type: object
+            properties:
+              users:
+                type: array
+                items:
+                  $ref: '#/definitions/User'
+
 parameters:
   connection_id:
     description: A unique connection identifier

--- a/t/web-user.t
+++ b/t/web-user.t
@@ -13,8 +13,9 @@ $ENV{CONVOS_TURN} = 'turn://superman:k2@turn.example.com:3478';
 my $t = t::Helper->t;
 
 $t->get_ok('/api/user')->status_is(401)->json_is('/errors/0/message', 'Need to log in first.');
-$t->delete_ok('/api/user')->status_is(401)->json_is('/errors/0/message', 'Need to log in first.');
-$t->post_ok('/api/user', json => {})->status_is(401)
+$t->delete_ok('/api/user/superman@example.com')->status_is(401)
+  ->json_is('/errors/0/message', 'Need to log in first.');
+$t->post_ok('/api/user/superman@example.com', json => {})->status_is(401)
   ->json_is('/errors/0/message', 'Need to log in first.')->json_is('/errors/0/path', '/');
 
 $t->post_ok('/api/user/register',
@@ -22,7 +23,7 @@ $t->post_ok('/api/user/register',
   ->json_is('/email', 'superman@example.com')->json_like('/registered', qr/^[\d-]+T[\d:]+Z$/);
 my $registered = $t->tx->res->json->{registered};
 
-$t->post_ok('/api/user', json => {})->status_is(200);
+$t->post_ok('/api/user/superman@example.com', json => {})->status_is(200);
 
 $t->get_ok('/api/user')->status_is(200);
 is_deeply(
@@ -57,8 +58,8 @@ is_deeply(
   'user object'
 );
 
-$t->post_ok('/api/user', json => {highlight_keywords => [' ', '-', '.', '  ,', '    ', 'foo ']})
-  ->status_is(200);
+$t->post_ok('/api/user/superman@example.com',
+  json => {highlight_keywords => [' ', '-', '.', '  ,', '    ', 'foo ']})->status_is(200);
 $t->get_ok('/api/user')->status_is(200)->json_is('/email', 'superman@example.com')
   ->json_is('/highlight_keywords', ['foo']);
 
@@ -98,7 +99,7 @@ $t->get_ok('/api/user?connections=true&dialogs=true')->status_is(200)
 
 $t->post_ok('/api/notifications/read')->status_is(200);
 
-$t->delete_ok('/api/user')->status_is(400)
+$t->delete_ok('/api/user/superman@example.com')->status_is(400)
   ->json_is('/errors/0/message', 'You are the only user left.');
 
 $t->get_ok('/api/user/logout')->status_is(200);

--- a/t/web-users.t
+++ b/t/web-users.t
@@ -1,0 +1,33 @@
+#!perl
+use lib '.';
+use t::Helper;
+
+$ENV{CONVOS_OPEN_TO_PUBLIC} = 1;
+
+my $t = t::Helper->t;
+
+note 'No user';
+$t->get_ok('/api/user')->status_is(401)->json_is('/errors/0/message', 'Need to log in first.');
+$t->get_ok('/api/users')->status_is(401)->json_is('/errors/0/message', 'Need to log in first.');
+
+note 'First user';
+$t->post_ok('/api/user/register',
+  json => {email => 'superman@example.com', password => '1234567890'})->status_is(200)
+  ->json_is('/email', 'superman@example.com')->json_like('/registered', qr/^[\d-]+T[\d:]+Z$/);
+$t->get_ok('/api/users')->status_is(200)->json_is('/users/0/email', 'superman@example.com')
+  ->json_is('/users/1', undef);
+$t->get_ok('/api/user/logout')->status_is(200);
+
+note 'Second user';
+$t->post_ok('/api/user/register',
+  json => {email => 'superwoman@example.com', password => '1234567890'})->status_is(200);
+$t->get_ok('/api/users')->status_is(401)->json_is('/errors/0/message', 'Need to log in first.');
+$t->get_ok('/api/user/logout')->status_is(200);
+
+note 'First user again';
+$t->post_ok('/api/user/login', json => {email => 'superman@example.com', password => '1234567890'})
+  ->status_is(200);
+$t->get_ok('/api/users')->status_is(200)->json_is('/users/0/email', 'superman@example.com')
+  ->json_is('/users/1/email', 'superwoman@example.com')->json_is('/users/2', undef);
+
+done_testing;

--- a/t/web-users.t
+++ b/t/web-users.t
@@ -8,7 +8,8 @@ my $t = t::Helper->t;
 
 note 'No user';
 $t->get_ok('/api/user')->status_is(401)->json_is('/errors/0/message', 'Need to log in first.');
-$t->get_ok('/api/users')->status_is(401)->json_is('/errors/0/message', 'Need to log in first.');
+$t->get_ok('/api/users')->status_is(403)
+  ->json_is('/errors/0/message', 'Only admins can list users.');
 
 note 'First user';
 $t->post_ok('/api/user/register',
@@ -16,18 +17,50 @@ $t->post_ok('/api/user/register',
   ->json_is('/email', 'superman@example.com')->json_like('/registered', qr/^[\d-]+T[\d:]+Z$/);
 $t->get_ok('/api/users')->status_is(200)->json_is('/users/0/email', 'superman@example.com')
   ->json_is('/users/1', undef);
+
+note 'Delete / update other users as admin';
+$t->delete_ok('/api/user/superduper@example.com')->status_is(200)->json_is('/message', 'Deleted.');
+$t->post_ok('/api/user/superduper@example.com', json => {})->status_is(404)
+  ->json_is('/errors/0/message', 'No such user.');
+
+note 'Logout first user';
 $t->get_ok('/api/user/logout')->status_is(200);
 
 note 'Second user';
 $t->post_ok('/api/user/register',
   json => {email => 'superwoman@example.com', password => '1234567890'})->status_is(200);
-$t->get_ok('/api/users')->status_is(401)->json_is('/errors/0/message', 'Need to log in first.');
+$t->get_ok('/api/users')->status_is(403)
+  ->json_is('/errors/0/message', 'Only admins can list users.');
+
+note 'Cannot change roles as normal user';
+$t->post_ok('/api/user/superwoman@example.com', json => {roles => ['admin']})->status_is(200);
+$t->get_ok('/api/user')->status_is(200)->json_is('/roles', []);
+
+note 'Delete / update other users as normal user';
+$t->delete_ok('/api/user/superman@example.com')->status_is(403)
+  ->json_is('/errors/0/message', 'Only admins can delete other users.');
+$t->post_ok('/api/user/superman@example.com', json => {})->status_is(403)
+  ->json_is('/errors/0/message', 'Only admins can update other users.');
+
+note 'Logout second user';
 $t->get_ok('/api/user/logout')->status_is(200);
 
 note 'First user again';
 $t->post_ok('/api/user/login', json => {email => 'superman@example.com', password => '1234567890'})
   ->status_is(200);
 $t->get_ok('/api/users')->status_is(200)->json_is('/users/0/email', 'superman@example.com')
-  ->json_is('/users/1/email', 'superwoman@example.com')->json_is('/users/2', undef);
+  ->json_is('/users/0/roles', ['admin'])->json_is('/users/1/email', 'superwoman@example.com')
+  ->json_is('/users/1/roles', [])->json_is('/users/2', undef);
+
+note 'Can change roles as admin';
+$t->post_ok('/api/user/superwoman@example.com', json => {roles => ['admin']})->status_is(200);
+$t->get_ok('/api/users')->status_is(200)->json_is('/users/0/email', 'superman@example.com')
+  ->json_is('/users/0/roles', ['admin'])->json_is('/users/1/email', 'superwoman@example.com')
+  ->json_is('/users/1/roles', ['admin'])->json_is('/users/2',       undef);
+
+note 'Delete user';
+is $t->app->core->n_users, 2, 'got two users left';
+$t->delete_ok('/api/user/superwoman@example.com')->status_is(200)->json_is('/message', 'Deleted.');
+is $t->app->core->n_users, 1, 'only one user left';
 
 done_testing;


### PR DESCRIPTION
This PR implements #417. I'm creating a PR, since pushing this to master will break the updateUser endpoint. Cannot be merged before rebuilding assets and creating a new release.

Features:

* Add "Users" link to main menu.
* Add /settings/users resource.
* Add SettingsAdminUsers.svelte component for inviting, listing, updating and deleting users #417.
* Add update of a user's "roles".
* Add "GET /api/users".
* Fix deleting user.
* Changed "has_may()" to return objects in a predictable order.
* Changed "POST /api/user" to "POST /api/user/:email"
* Changed "DELETE /api/user" to "DELETE /api/user/:email"
* Moved invite functionality from SettingsAdmin.svelte to SettingsAdminUsers.svelte.
* OperationStatus.svelte can show a loading/progress bar.
* Time.getHumanDate() can be forced to render "year".