### PR TITLE
Fix exif rotation

### DIFF
--- a/assets/js/EmbedMaker.js
+++ b/assets/js/EmbedMaker.js
@@ -149,16 +149,21 @@ export default class EmbedMaker extends Reactive {
 
     let maxBytes = dv.byteLength;
     let pos = 2;
+    var littleEndian = false;
     while (pos < maxBytes - 2 && !img.orientation) {
       const uint16 = dv.getUint16(pos);
       pos += 2;
       switch (uint16) {
         case 0xffe1: // Start of EXIF
-          maxBytes = dv.getUint16(pos) + pos;
+          var endianNess = scanner.getUint16(idx + 8);
+          if (endianNess === 0x4949) {
+            littleEndian = true;
+          }
+          maxBytes = dv.getUint16(pos, littleEndian)-pos;
           pos += 2;
           break;
         case 0x0112: // Orientation tag
-          img.orientation = exifRotation[dv.getUint16(pos + 6, false)];
+          img.orientation = exifRotation[dv.getUint16(pos + 6, littleEndian)];
           break;
       }
     }


### PR DESCRIPTION
According to this gist
https://gist.github.com/runeb/c11f864cd7ead969a5f0 exif rotation is
required to handle endianness to work on all files. Tested this change
locally and it rotated the file from #convos earlier today correctly.