### PR TITLE
Remove ! prefix from public commands

### DIFF
--- a/lib/Convos/Plugin/Bot.pm
+++ b/lib/Convos/Plugin/Bot.pm
@@ -169,9 +169,8 @@ sub _run_actions_with_message {
   my $connection = $self->user->get_connection($event->{connection_id});
   return if lc $event->{from} eq lc $connection->nick;
 
-  my $command = $event->{message};
   local $event->{is_private} = $event->{dialog_id} =~ m!^$CHANNEL_RE! ? 0 : 1;
-  local $event->{command} = $command =~ s/^\!// ? $command : $event->{is_private} ? $command : '';
+  local $event->{command} = $event->{message};
 
   my $reply;
   for my $config (@{$self->config->get('/actions')}) {

--- a/lib/Convos/Plugin/Bot/Action/Karma.pm
+++ b/lib/Convos/Plugin/Bot/Action/Karma.pm
@@ -20,7 +20,7 @@ sub register {
 
 sub reply {
   my ($self, $event) = @_;
-  return unless $event->{command} =~ m/^karma\s+(.+)/i;
+  return undef unless $event->{command} =~ m/^karma\s+(.+)/i;
 
   my $topic = $1;
   $topic =~ s/[?!.]$//;


### PR DESCRIPTION
----

# Remove ! prefix

I didn't find any documentation or tests that were affected by 
this change. I think the user experience is better without the
! prefix, but as an alternative, we could make the prefix configurable
and default to an empty prefix.