### PR TITLE
Upgrade Docker Alpine version to 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 # BUILD: docker build --no-cache --rm -t nordaaker/convos .
 # RUN:   docker run -it --rm -p 8080:3000 -v /var/convos/data:/data nordaaker/convos
-FROM alpine:3.11
+FROM alpine:3.12
 LABEL maintainer="jhthorsen@cpan.org"
 
 RUN mkdir /app


### PR DESCRIPTION
Alpine 3.12 comes with updated libraries: https://www.alpinelinux.org/posts/Alpine-3.12.0-released.html

Perl is on version 5.30.3-r0 on both Alpine 3.11 (old version) and Alpine 3.12 (new version). The build tools, on the other hand, have been updated in Alpine 3.12.