### PR TITLE
Force LF line ending for executable Perl scripts (fix Docker on Windows)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+script/* eol=lf


### PR DESCRIPTION
When building the Dockerfile with default Git settings on Docker for Windows, the build fails right after installing dependencies:

```
...
(19/21) Installing perl-utils (5.30.3-r0)
(20/21) Installing perl-dev (5.30.3-r0)
(21/21) Installing builddeps (20200917.205502)
Executing busybox-1.31.1-r9.trigger
OK: 225 MiB in 43 packages
': No such file or directory
The command '/bin/sh -c apk add --no-cache perl perl-io-socket-ssl wget &&     apk add --no-cache --virtual builddeps build-base perl-dev &&     /app/script/convos install --all &&     apk del builddeps && rm -rf /root/.cpanm /var/cache/apk/*' returned a non-zero code: 127
```

This is because when /bin/sh runs `/app/script/convos`, it opens the script and looks for a shebang line to figure out which executable to run the script with.

In other words, it's looking for `#!/usr/bin/env perl`.

However, since `/app/script/convos` is using CRLF line endings, `/bin/sh` does not know how to find the shebang, and therefore it doesn't know how to execute `/app/script/convos`.

This commit adds a `.gitattributes` file which forces Git to checkout all files inside the "script" directory with LF line endings. This allows the build script to continue successfully.