### PR TITLE
Ensure markdown link text start with a letter

### DIFF
--- a/__tests__/md.js
+++ b/__tests__/md.js
@@ -35,6 +35,8 @@ test('code', () => {
     .toBe('is this <code>not code</code>, or..?');
   expect(md('not a `https://link.com`'))
     .toBe('not a <code><a href="https://link.com" target="_blank">https://link.com</a></code>');
+  expect(md('a regexp: `TShop\.Setup\(\s*([{](?>[^\\"{}]+|"(?>[^\\"]+|\\[\S\s])*"|\\[\S\s]|(?-1))*[}])`'))
+    .toBe('a regexp: <code>TShop\.Setup\(\s*([{](?&gt;[^\\&quot;{}]+|&quot;(?&gt;[^\\&quot;]+|\\[\S\s])*&quot;|\\[\S\s]|(?-1))*[}])</code>');
 });
 
 function countEmojis(str) {

--- a/assets/js/md.js
+++ b/assets/js/md.js
@@ -135,7 +135,7 @@ function mdEmStrong(str) {
 }
 
 function mdLink(str, state = {}) {
-  return str.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (all, text, href) => {
+  return str.replace(/\[([a-zA-Z][^\]]+)\]\(([^)]+)\)/g, (all, text, href) => {
     const scheme = href.match(/^\s*(\w+):/) || ['', ''];
     if (scheme[1] && ['http', 'https', 'mailto'].indexOf(scheme[1]) == -1) return all; // Avoid XSS links
     state.mdLinks = true;


### PR DESCRIPTION
Make link generation more strict to avoid accidentally triggering on regular expressions and such.

Was wondering if we should allow white space before and/or to start with a number, but I couldn't come up with any good use cases.