### PR TITLE
Fix jumping to bottom of conversation on initial render

### DIFF
--- a/assets/components/InfinityScroll.svelte
+++ b/assets/components/InfinityScroll.svelte
@@ -2,17 +2,19 @@
 import {createEventDispatcher} from 'svelte';
 import {findVisibleElements, isType} from '../js/util';
 
+const DEBUG = false;
 const dispatch = createEventDispatcher();
 const state = {scrollDelay: 80, scrollOffset: 80, scrollTop: 0};
 
+let cancelNextScroll = true;
 let className = '';
-let isManuallyScrolled = true;
 let scrollHeight = 0;
 
 export {className as class};
 export let pos = 'top';
 
 $: classNames = [className || 'infinity-scroll'].concat(['has-pos-' + pos]);
+$: DEBUG && console.log(location.href + ': ' + scrollHeight);
 
 function calculateDetails(infinityEl) {
   pos = infinityEl.scrollTop > scrollHeight - infinityEl.offsetHeight - state.scrollOffset ? 'bottom'
@@ -34,12 +36,21 @@ function onReady(infinityEl, params) {
 
 function onScroll(infinityEl) {
   if (state.scrollTid) clearTimeout(state.scrollTid);
-  if (Math.abs(state.scrollTop - state.infinityEl.scrollTop) > 600) onScrolled(infinityEl); // 600 is a more or less randomly picked number
   state.scrollTid = setTimeout(() => onScrolled(infinityEl), state.scrollDelay);
 }
 
 function onScrolled(infinityEl) {
-  if (isManuallyScrolled) return (isManuallyScrolled = false);
+  if (DEBUG) console.log('onScrolled pos=' + state.scrollTop + '/' + infinityEl.scrollTop + ' cancelNextScroll=' + cancelNextScroll);
+
+  if (cancelNextScroll) {
+    // onScrolled() can will get triggered when scrollTo() changes infinityEl.scrollTop.
+    // Need to cancel the next "scroll" event as well, in case "scrollTop" was not set correctly.
+    cancelNextScroll = Math.abs(infinityEl.scrollTop - state.scrollTop) > 40;
+    if (cancelNextScroll) infinityEl.scrollTop = state.scrollTop;
+    if (state.scrollTid) clearTimeout(state.scrollTid);
+    return;
+  }
+
   state.scrollTop = infinityEl.scrollTop;
   calculateDetails(infinityEl);
   dispatch('scrolled', state);
@@ -54,12 +65,15 @@ function onUpdate(infinityEl, {scrollHeight}) {
 
 function scrollTo(pos) {
   if (isType(pos, 'undef')) return false;
-  if (pos == -1) pos = scrollHeight - pos;
+  if (pos == -1) pos = scrollHeight;
   if (isType(pos, 'string')) pos = state.infinityEl.querySelector(pos);
   if (pos && pos.tagName) pos = pos.offsetTop;
   if (isType(pos, 'undef')) return false;
-  isManuallyScrolled = true;
+  if (pos < 0) return false;
+  cancelNextScroll = true;
   state.infinityEl.scrollTop = pos;
+  state.scrollTop = state.infinityEl.scrollTop;
+  if (DEBUG) console.log('scrollTo pos=' + pos + '/' + state.scrollTop);
   return true;
 }
 </script>


### PR DESCRIPTION
Looks like setting `el.scrollTop` does not always do the correct thing.

1. Notifications page gets loaded
2. InfinityScroll.svelte trigger `rendered` event
3. Search.svelte calls `e.detail.scrollTo(-1)`
4. InfinityScroll.svelte translates `pos=-1` to `pos=1692`, but since `scrollHeight` is higher than the actual max scroll, `scrollTop` has the value of `873` after set to `1692`.
5. Changing `scrollTop` triggers `onScrolled()`
6. Reading `scrollTop` inside `onScrolled()` is no longer `873`, but `83`.

So why changes `scrollTop` between step 4 and 6? I don't know, but this PR tries to improve how locking on non-human scroll events are handled.