### PR TITLE
Show more info from WHOIS response by default

### DIFF
--- a/assets/store/Connection.js
+++ b/assets/store/Connection.js
@@ -187,10 +187,9 @@ export default class Connection extends Conversation {
     this.ensureConversation(params);
   }
 
-  // TODO: Reply should be shown in the active conversation instead
   wsEventSentWhois(params) {
-    let message = '%1 (%2)';
-    let vars = [params.nick, params.host];
+    let message = '%1 (%2@%3, %4)';
+    let vars = [params.nick, params.user, params.host, params.name];
 
     const channels = Object.keys(params.channels).sort().map(name => (modeMoniker[params.channels[name].mode] || '') + name);
     params.channels = channels;


### PR DESCRIPTION
We used to say "nick (host) is …"

Now we say "nick (user@host, ircname) is …"

(Also remove outdated comment about displaying whois response in current
conversation, which seems to work correctly now.)