### PR TITLE
Add "realname" as a new connection parameter

### DIFF
--- a/assets/components/ConnectionForm.svelte
+++ b/assets/components/ConnectionForm.svelte
@@ -54,6 +54,7 @@ function defaultsToForm() {
   if (connURL.password) formEl.password.value = connURL.password;
   if (connURL.username) formEl.username.value = connURL.username;
   if (connParams.get('nick')) formEl.nick.value = connParams.get('nick');
+  if (connParams.get('realname')) formEl.realname.value = connParams.get('realname');
   if (connURL.pathname && formEl.conversation) formEl.conversation.value = decodeURIComponent(connURL.pathname.split('/').filter(p => p.length)[0] || '');
   if (Number(connParams.get('tls') || 0)) useTls = true;
   if (Number(connParams.get('tls_verify') || 0)) verifyTls = true;
@@ -63,6 +64,7 @@ function connectionToForm() {
   if (!connection.url) return; // Could not find connection
   formEl.server.value = connection.url.host;
   formEl.nick.value = connection.url.searchParams.get('nick') || '';
+  formEl.realname.value = connection.url.searchParams.get('realname') || '';
   formEl.on_connect_commands.value = connection.on_connect_commands.join('\n');
   formEl.password.value = connection.url.password;
   formEl.username.value = connection.url.username;
@@ -110,8 +112,12 @@ async function submitForm(e) {
     </p>
   </TextField>
 
-  <TextField name="nick" placeholder="{l('Ex: your-name')}">
+  <TextField name="nick" placeholder="{l('Ex: superman')}">
     <span slot="label">{l('Nickname')}</span>
+  </TextField>
+
+  <TextField name="realname" placeholder="{l('Ex: Clark Kent')}">
+    <span slot="label">{l('Your name (visible in WHOIS)')}</span>
   </TextField>
 
   {#if connection.url}

--- a/assets/js/ConnectionURL.js
+++ b/assets/js/ConnectionURL.js
@@ -38,6 +38,7 @@ export default class ConnectionURL {
   fromForm(form) {
     const server = form.server.value;
     if (form.nick.value.length) this.searchParams.append('nick', form.nick.value);
+    if (form.realname.value.length) this.searchParams.append('realname', form.realname.value);
     this.searchParams.append('tls', form.tls.checked ? '1' : '0');
     this.searchParams.append('tls_verify', form.tls_verify && form.tls_verify.checked ? '1' : '0');
     this.host = server.match(/:\d+$/) ? server : server + ':6667';

--- a/lib/Convos/Core/Connection/Irc.pm
+++ b/lib/Convos/Core/Connection/Irc.pm
@@ -1062,7 +1062,11 @@ sub _stream {
   $self->_write("CAP LS\r\n");
   $self->_write(sprintf "PASS %s\r\n", $url->password) if length $url->password;
   $self->_write("NICK $nick\r\n");
-  $self->_write("USER $user $mode * :https://convos.chat/\r\n");
+
+  my $convos = "https://convos.chat";
+  my $realname = $url->query->param('realname');
+  $realname = $realname ? "$realname via $convos" : $convos;
+  $self->_write("USER $user $mode * :$realname\r\n");
 }
 
 sub _stream_on_read {

--- a/t/Server/Irc.pm
+++ b/t/Server/Irc.pm
@@ -145,7 +145,14 @@ sub _find_server_conn {
 
 sub _handle_client_connect {
   my ($self, $c_conn) = @_;
-  $c_conn->url($self->url)->connect_p unless $c_conn->state eq 'connected';
+
+  unless ($c_conn->state eq 'connected') {
+    $c_conn->url->host($self->url->host);
+    $c_conn->url->port($self->url->port);
+    $c_conn->url->query->param($_ => $self->url->query->param($_)) for @{$self->url->query->names};
+    $c_conn->connect_p;
+  }
+
   $self->_dequeue;
 }
 

--- a/t/irc-connect-realname.t
+++ b/t/irc-connect-realname.t
@@ -1,0 +1,35 @@
+#!perl
+BEGIN { $ENV{CONVOS_SKIP_CONNECT} = 1 }
+use lib '.';
+use t::Helper;
+use t::Server::Irc;
+use Convos::Core;
+use Convos::Core::Backend::File;
+use Test::Deep;
+
+use lib '.';
+use t::Helper;
+use t::Server::Irc;
+use Convos::Core;
+use Convos::Core::Backend::File;
+use Test::Deep;
+
+my $server = t::Server::Irc->new->start;
+my $core   = Convos::Core->new(backend => 'Convos::Core::Backend::File');
+my $user   = $core->user({email => 'test.user@example.com'});
+$user->save_p->$wait_success;
+
+my $connection = $user->connection({name => 'example', protocol => 'irc'});
+$connection->url->query->param(realname => 'Clark Kent');
+$connection->save_p->$wait_success;
+
+my $test_user_command = sub {
+  my ($conn, $msg) = @_;
+  is_deeply $msg->{params}, ['test_user', '0', '*', 'Clark Kent via https://convos.chat'], 'got expected USER command';
+};
+
+$server->client($connection)->server_event_ok('_irc_event_nick')
+  ->server_event_ok('_irc_event_user', $test_user_command)->server_write_ok(['welcome.irc'])
+  ->client_event_ok('_irc_event_rpl_welcome')->process_ok;
+ 
+done_testing;

--- a/t/irc-connect.t
+++ b/t/irc-connect.t
@@ -35,7 +35,7 @@ $connection->on_connect_commands([@on_connect_commands]);
 
 my $test_user_command = sub {
   my ($conn, $msg) = @_;
-  is_deeply $msg->{params}, [qw(test_user 0 * https://convos.chat/)], 'got expected USER command';
+  is_deeply $msg->{params}, [qw(test_user 0 * https://convos.chat)], 'got expected USER command';
 };
 $server->client($connection)->server_event_ok('_irc_event_nick')
   ->server_event_ok('_irc_event_user', $test_user_command)->server_write_ok(['welcome.irc'])


### PR DESCRIPTION
You can use this to set the realname which is sent to the IRC server in
the initial USER command, and will be displayed in your WHOIS output.

Convos will append "via https://convos.chat" to the value you specify,
so as to have a simple and mostly-reliable way to detect other clients
using Convos.