### PR TITLE
Don't send a username with a non-alphanumeric first character

### DIFF
--- a/lib/Convos/Core/Connection/Irc.pm
+++ b/lib/Convos/Core/Connection/Irc.pm
@@ -1058,6 +1058,7 @@ sub _stream {
   my $url  = $self->url;
   my $nick = $self->nick;
   my $user = $url->username || $nick;
+  $user =~ s/^[^a-z0-9]/x/;
   my $mode = $url->query->param('mode') || 0;
   $self->_write("CAP LS\r\n");
   $self->_write(sprintf "PASS %s\r\n", $url->password) if length $url->password;

--- a/t/irc-connect-realname.t
+++ b/t/irc-connect-realname.t
@@ -20,12 +20,13 @@ my $user   = $core->user({email => 'test.user@example.com'});
 $user->save_p->$wait_success;
 
 my $connection = $user->connection({name => 'example', protocol => 'irc'});
+$connection->url->query->param(nick => '_superman');
 $connection->url->query->param(realname => 'Clark Kent');
 $connection->save_p->$wait_success;
 
 my $test_user_command = sub {
   my ($conn, $msg) = @_;
-  is_deeply $msg->{params}, ['test_user', '0', '*', 'Clark Kent via https://convos.chat'], 'got expected USER command';
+  is_deeply $msg->{params}, ['xsuperman', '0', '*', 'Clark Kent via https://convos.chat'], 'got expected USER command';
 };
 
 $server->client($connection)->server_event_ok('_irc_event_nick')


### PR DESCRIPTION
Setting your nick to _xxx is fine, but sending _xxx as a username in the
initial USER command is not accepted at least by Freenode. This username
doesn't really matter if it's being generated from the nick anyway, so
we can just change any initial non-alphanumeric character to 'x'.