### PR TITLE
Add a "compact display" mode as Viewport option

### DIFF
--- a/assets/page/SettingsAccount.svelte
+++ b/assets/page/SettingsAccount.svelte
@@ -16,6 +16,7 @@ const user = getContext('user');
 const updateUserOp = api('updateUser');
 
 let formEl;
+let compactDisplay = viewport.compactDisplay;
 let expandUrlToMedia = viewport.expandUrlToMedia;
 let highlightKeywords = user.highlightKeywords.join(', ');
 let selectedColorScheme = viewport.colorScheme;
@@ -54,7 +55,7 @@ function updateUserFromForm(e) {
   }
 
   notify.update({wantNotifications});
-  viewport.update({expandUrlToMedia});
+  viewport.update({expandUrlToMedia, compactDisplay});
   user.update({ignoreStatuses});
   viewport.activateTheme(selectedTheme, colorSchemeReadonly ? '' : selectedColorScheme);
   updateUserOp.perform(e.target);
@@ -94,6 +95,10 @@ function updateUserFromForm(e) {
     <SelectField name="color_scheme" readonly="{colorSchemeReadonly}" options="{viewport.colorSchemeOptions}" bind:value="{selectedColorScheme}">
       <span slot="label">{l('Color scheme')}</span>
     </SelectField>
+
+    <Checkbox name="compact" bind:checked="{compactDisplay}">
+      <span slot="label">{l('Enable compact message display')}</span>
+    </Checkbox>
 
     <TextField type="password" name="password" autocomplete="new-password">
       <span slot="label">{l('Password')}</span>

--- a/assets/sass/components/_chat-messages.scss
+++ b/assets/sass/components/_chat-messages.scss
@@ -268,3 +268,19 @@
     cursor: inherit;
   }
 }
+
+body.is-compact {
+  .message {
+    &.has-not-same-from {
+      margin-top: 0.2rem;
+    }
+  }
+
+  .message__from {
+    display: inline;
+  }
+
+  .message__text {
+    display: inline;
+  }
+}

--- a/assets/store/Viewport.js
+++ b/assets/store/Viewport.js
@@ -6,6 +6,7 @@ export default class Viewport extends Reactive {
     super();
     this.prop('cookie', 'colorScheme', 'auto');
     this.prop('cookie', 'theme', 'convos');
+    this.prop('cookie', 'compactDisplay', false);
     this.prop('persist', 'expandUrlToMedia', true);
     this.prop('persist', 'version', '');
     this.prop('ro', 'colorSchemeOptions', ['Auto', 'Light', 'Dark'].map(o => [o.toLowerCase(), o]));
@@ -108,6 +109,12 @@ export default class Viewport extends Reactive {
     if (key == 'contact') value = btoa(value);
     if (typeof value == 'boolean') value = value ? 'yes' : 'no';
     el.content = value;
+  }
+
+  update(params) {
+    const body = document.getElementsByTagName('body')[0];
+    body.classList[this.compactDisplay ? 'add' : 'remove']('is-compact');
+    return super.update(params);
   }
 }
 

--- a/templates/layouts/convos.html.ep
+++ b/templates/layouts/convos.html.ep
@@ -66,7 +66,7 @@
     % }
     %= tag style => sub { stash 'custom_css' } if stash 'custom_css'
   </head>
-  <body class="no-js notify-disabled for-cms">
+  <body class="no-js notify-disabled for-cms <%= js_session('compactDisplay') ? ' is-compact' : '' =%>">
     %= content
     %= asset 'convos.js' unless stash 'exception'
   </body>


### PR DESCRIPTION
Selecting this checkbox on the "account settings" page applies a new
.is-compact class to the body, which changes a few of the CSS rules
applied to messages in order to use less vertical space.

This could use more CSS tweaks, but I'm posting it for review since the functionality works.