### PR TITLE
Allow leading uppercase characters in usernames

### DIFF
--- a/lib/Convos/Core/Connection/Irc.pm
+++ b/lib/Convos/Core/Connection/Irc.pm
@@ -1069,7 +1069,7 @@ sub _stream {
   my $url  = $self->url;
   my $nick = $self->nick;
   my $user = $url->username || $nick;
-  $user =~ s/^[^a-z0-9]/x/;
+  $user =~ s/^[^a-zA-Z0-9]/x/;
   my $mode = $url->query->param('mode') || 0;
   $self->_write("CAP LS\r\n");
   $self->_write(sprintf "PASS %s\r\n", $url->password) if length $url->password;

--- a/t/irc-connect-realname.t
+++ b/t/irc-connect-realname.t
@@ -33,4 +33,16 @@ $server->client($connection)->server_event_ok('_irc_event_nick')
   ->server_event_ok('_irc_event_user', $test_user_command)->server_write_ok(['welcome.irc'])
   ->client_event_ok('_irc_event_rpl_welcome')->process_ok;
  
+$connection->disconnect_p->$wait_success('disconnect_p');
+$connection->url->query->param(nick => 'Superman');
+
+my $test_User_command = sub {
+  my ($conn, $msg) = @_;
+  is_deeply $msg->{params}, ['Superman', '0', '*', 'Clark Kent via https://convos.chat'], 'got expected USER command';
+};
+
+$server->client($connection)->server_event_ok('_irc_event_nick')
+  ->server_event_ok('_irc_event_user', $test_User_command)->server_write_ok(['welcome.irc'])
+  ->client_event_ok('_irc_event_rpl_welcome')->process_ok;
+
 done_testing;


### PR DESCRIPTION
This was just an oversight in the earlier commit, there's no problem
with using an initial uppercase character.